### PR TITLE
fix: remove unused filters arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make docker-build docker-push IMG=ghcr.io/open-digital-twin/ktwin-operator:0.1
 3. Deploy the controller to the cluster with the image specified by `IMG`:
 
 ```sh
-make deploy IMG=ghcr.io/open-digital-twin/ktwin-operator@sha256:d17285f3e2852023c0dc0d0389615ea96e81ed594d2de8fa480ca178ca2a7b08
+make deploy IMG=ghcr.io/open-digital-twin/ktwin-operator@sha256:0ff3ae893e090370b1b0ec689dabe06df6bd112d3940c0215892ae4373e6f21e
 ```
 
 ### Uninstall CRDs

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -151,11 +151,9 @@ func (e *twinEvent) GetVirtualCloudEventBrokerBinding(
 			"eventing.knative.dev/trigger": twinInterface.Name,
 		},
 		Filters: map[string]string{
-			"type":                         e.getEventTypeVirtualGenerated(twinInterface.Name),
-			"x-knative-trigger":            twinInterface.Name,
-			"x-match":                      "all",
-			"ktwin/twin-interface":         twinInterface.Name,
-			"eventing.knative.dev/trigger": twinInterface.Name,
+			"type":              e.getEventTypeVirtualGenerated(twinInterface.Name),
+			"x-knative-trigger": twinInterface.Name,
+			"x-match":           "all",
 		},
 		RabbitMQVhost: "/",
 		Owner: []v1.OwnerReference{

--- a/pkg/graph/twinInstanceGraph_test.go
+++ b/pkg/graph/twinInstanceGraph_test.go
@@ -163,11 +163,6 @@ func TestTwinInstance_AddVertex(t *testing.T) {
 
 func TestTwinInstance_MarshalJSON(t *testing.T) {
 
-	type VertexToBeAdded struct {
-		twinInstance  dtdv0.TwinInstance
-		expectedError error
-	}
-
 	tests := []struct {
 		name                     string
 		initialTwinInstanceGraph twinInstanceGraph
@@ -204,6 +199,7 @@ func TestTwinInstance_MarshalJSON(t *testing.T) {
 			expectedResult: "{\"twinInstances\":[{\"name\":\"TwinInstance01\",\"relationships\":[{\"name\":\"NameRelationship01\",\"interface\":\"InterfaceRelationship01\",\"instance\":\"InstanceRelationship02\"}]},{\"name\":\"TwinInstance02\",\"relationships\":[{\"name\":\"NameRelationship02\",\"interface\":\"InterfaceRelationship02\",\"instance\":\"InstanceRelationship02\"}]}]}",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.initialTwinInstanceGraph.MarshalJson()
@@ -212,7 +208,7 @@ func TestTwinInstance_MarshalJSON(t *testing.T) {
 				assert.Fail(t, "Error is not supposed to be different of nul")
 			}
 
-			assert.Equal(t, tt.expectedResult, string(result))
+			assert.JSONEq(t, tt.expectedResult, string(result))
 		})
 	}
 }


### PR DESCRIPTION
Removing unused arguments from cloud event dispatcher queue.